### PR TITLE
support less granular advanced search date params

### DIFF
--- a/backend/app/model/advanced_query_string.rb
+++ b/backend/app/model/advanced_query_string.rb
@@ -2,7 +2,7 @@ require 'time'
 
 class AdvancedQueryString
   def initialize(query, use_literal)
-    @query = query
+    @query = query.transform_keys { |k| k.to_s }
     @use_literal = use_literal
   end
 
@@ -40,7 +40,8 @@ class AdvancedQueryString
 
   def value
     if date?
-      base_time = Time.parse(@query["value"]).utc.iso8601
+      date_string = @query["value"].split('-').concat(["01", "01"]).take(3).join("-")
+      base_time = Time.parse(date_string).utc.iso8601
 
       if @query["comparator"] == "lesser_than"
         "[* TO #{base_time}-1MILLISECOND]"

--- a/backend/spec/model_advanced_query_string_spec.rb
+++ b/backend/spec/model_advanced_query_string_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "AdvancedQueryString" do
+
+  it "can support date granularity of day, month, or year" do
+    query = {"field":"create_time","value":"1911-03-01","comparator":"greater_than","jsonmodel_type":"date_field_query","negated":false}
+    advancedQueryString = AdvancedQueryString.new(query, false)
+    expect(advancedQueryString.to_solr_s).to match /create_time:\[1911-03-01T\d{2}:00:00Z\+1DAY TO \*\]/
+
+    query = {"field":"create_time","value":"1911-03","comparator":"greater_than","jsonmodel_type":"date_field_query","negated":false}
+    advancedQueryString = AdvancedQueryString.new(query, false)
+    expect(advancedQueryString.to_solr_s).to match /create_time:\[1911-03-01T\d{2}:00:00Z\+1DAY TO \*\]/
+
+    query = {"field":"create_time","value":"1911","comparator":"greater_than","jsonmodel_type":"date_field_query","negated":false}
+    advancedQueryString = AdvancedQueryString.new(query, false)
+    expect(advancedQueryString.to_solr_s).to match /create_time:\[1911-01-01T\d{2}:00:00Z\+1DAY TO \*\]/
+  end
+end


### PR DESCRIPTION
This should allow the advanced search to work with more relaxed date param granularity.

## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
