### PR TITLE
make use of JSONModel normalise_date function to support less granula…

### DIFF
--- a/backend/app/model/advanced_query_string.rb
+++ b/backend/app/model/advanced_query_string.rb
@@ -40,7 +40,7 @@ class AdvancedQueryString
 
   def value
     if date?
-      date_string = @query["value"].split('-').concat(["01", "01"]).take(3).join("-")
+      date_string = JSONModel::Validations.normalise_date(@query["value"])
       base_time = Time.parse(date_string).utc.iso8601
 
       if @query["comparator"] == "lesser_than"

--- a/common/advanced_query_builder.rb
+++ b/common/advanced_query_builder.rb
@@ -148,6 +148,7 @@ class AdvancedQueryBuilder
     if query_data.is_a?(JSONModelType)
       query_data
     elsif query_data['type'] == "date"
+      query_data['value'] = JSONModel::Validations.normalise_date(query_data['value'])
       JSONModel::JSONModel(:date_field_query).from_hash(query_data)
     elsif query_data['type'] == "boolean"
       JSONModel::JSONModel(:boolean_field_query).from_hash(query_data)


### PR DESCRIPTION
This kind of negates the need for the previous work on the backend model, but it does no harm to leave it there. Since the JSONModel domain validates fields with type 'date', the query value needs to get fully granular before it can be packaged and sent to the backend. 


## Related JIRA Ticket or GitHub Issue
<!--- Please link to the JIRA Ticket or GitHub Issue here: -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have authority to submit this code.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
